### PR TITLE
[Feat] 지출 CRUD (API)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,32 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    //querydsl
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// Querydsl
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(generated)
 }

--- a/src/main/java/dev/golddiggerapi/config/QuerydslConfig.java
+++ b/src/main/java/dev/golddiggerapi/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package dev.golddiggerapi.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/ExpenditureCategoryController.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/ExpenditureCategoryController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/expenditure/categories")
+@RequestMapping("/api/expenditures/categories")
 @RequiredArgsConstructor
 public class ExpenditureCategoryController {
 

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/ExpenditureController.java
@@ -1,0 +1,74 @@
+package dev.golddiggerapi.expenditure.controller;
+
+import dev.golddiggerapi.expenditure.controller.dto.*;
+import dev.golddiggerapi.expenditure.service.ExpenditureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/expenditures")
+public class ExpenditureController {
+
+    private final ExpenditureService expenditureService;
+
+    @PostMapping("/{categoryId}")
+    public ResponseEntity<String> createExpenditure(@PathVariable Long categoryId,
+                                                    @Validated @RequestBody ExpenditureRequest request) {
+        // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
+        String mockAccountName = "abc";
+        String res = expenditureService.createExpenditure(mockAccountName, categoryId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(res);
+    }
+
+    @PatchMapping("/{expenditureId}")
+    public ResponseEntity<String> updateExpenditure(@PathVariable Long expenditureId,
+                                                    @Validated @RequestBody ExpenditureUpdateRequest request) {
+        // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
+        String mockAccountName = "abc";
+        String res = expenditureService.updateExpenditure(mockAccountName, expenditureId, request);
+        return ResponseEntity.ok().body(res);
+    }
+
+    @GetMapping("/{expenditureId}")
+    public ResponseEntity<ExpenditureResponse> getExpenditure(@PathVariable Long expenditureId) {
+        // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
+        String mockAccountName = "abc";
+        ExpenditureResponse res = expenditureService.getExpenditure(mockAccountName, expenditureId);
+        return ResponseEntity.ok().body(res);
+    }
+
+    @GetMapping
+    public ResponseEntity<ExpenditureByUserResponse> getExpendituresByUser(@RequestParam(value = "start") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate start,
+                                                                           @RequestParam(value = "end") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate end,
+                                                                           @RequestParam(value = "categoryId", required = false) Long categoryId,
+                                                                           @RequestParam(value = "minAndMax", required = false) Boolean hasMinAndMax) {
+        // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
+        String mockAccountName = "abc";
+        ExpenditureByUserRequest request = new ExpenditureByUserRequest(start, end, categoryId, hasMinAndMax);
+        ExpenditureByUserResponse res = expenditureService.getExpendituresByUser(mockAccountName, request);
+        return ResponseEntity.ok().body(res);
+    }
+
+    @DeleteMapping("/{expenditureId}")
+    public ResponseEntity<String> deleteExpenditure(@PathVariable Long expenditureId) {
+        // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
+        String mockAccountName = "abc";
+        String res = expenditureService.deleteExpenditure(mockAccountName, expenditureId);
+        return ResponseEntity.ok().body(res);
+    }
+
+    @PatchMapping("/{expenditureId}/exclude")
+    public ResponseEntity<String> excludeExpenditure(@PathVariable Long expenditureId) {
+        // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
+        String mockAccountName = "abc";
+        String res = expenditureService.excludeExpenditure(mockAccountName, expenditureId);
+        return ResponseEntity.ok().body(res);
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByUserRequest.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByUserRequest.java
@@ -1,0 +1,44 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+
+@Getter
+public class ExpenditureByUserRequest {
+
+    private final LocalDateTime start;
+
+    private final LocalDateTime end;
+
+    private final Long categoryId;
+
+    private final Boolean hasMinAndMax;
+
+    public ExpenditureByUserRequest(LocalDate start, LocalDate end, Long categoryId, Boolean hasMinAndMax) {
+        this.start = start.atStartOfDay();
+        this.end = end.atStartOfDay();
+        this.categoryId = categoryId;
+        this.hasMinAndMax = Objects.requireNonNullElse(hasMinAndMax, false);
+        validateDate(start, end);
+    }
+
+    private void validateDate(LocalDate start, LocalDate end) {
+        LocalDate dayOfServiceStart = LocalDate.of(2023, Month.JANUARY, 2);
+        if (start.isBefore(dayOfServiceStart) || end.isBefore(dayOfServiceStart)) {
+            throw new IllegalArgumentException("non service day");
+        }
+        if (start.isAfter(end)) {
+            throw new IllegalArgumentException("start can't after end");
+        }
+
+        long period = ChronoUnit.DAYS.between(start, end);
+        if (period >= 30) {
+            throw new IllegalArgumentException("period is up to 30 days");
+        }
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByUserResponse.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByUserResponse.java
@@ -1,0 +1,11 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import java.util.List;
+
+public record ExpenditureByUserResponse(
+        Long expenditureSum,
+        ExpenditureMinAndMax expenditureMinAndMax,
+        List<ExpenditureCategoryAndAmountResponse> expenditureCategoryAndAmountResponses,
+        List<ExpenditureMemoAndAmountResponse> expenditureMemoAndAmountResponses
+) {
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureCategoryAndAmountResponse.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureCategoryAndAmountResponse.java
@@ -1,0 +1,14 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ExpenditureCategoryAndAmountResponse(
+        Long categoryId,
+        String name,
+        Long sum
+) {
+
+    @QueryProjection
+    public ExpenditureCategoryAndAmountResponse {
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureMemoAndAmountResponse.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureMemoAndAmountResponse.java
@@ -1,0 +1,13 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ExpenditureMemoAndAmountResponse(
+        Long categoryId,
+        String memo,
+        Long amount
+) {
+    @QueryProjection
+    public ExpenditureMemoAndAmountResponse {
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureMinAndMax.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureMinAndMax.java
@@ -1,0 +1,12 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ExpenditureMinAndMax(
+        Long min,
+        Long max
+) {
+    @QueryProjection
+    public ExpenditureMinAndMax {
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureRequest.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureRequest.java
@@ -1,0 +1,18 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record ExpenditureRequest(
+        //'yyyy-MM-dd HH:00' 형식 1차 validation -> ssss-wm-ei 2m:00 으로
+        @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:00")
+        @NotBlank
+        String dateTime,
+        @Min(value = 0)
+        Long amount,
+        @NotNull
+        String memo
+) {
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureResponse.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureResponse.java
@@ -1,0 +1,28 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import dev.golddiggerapi.expenditure.domain.Expenditure;
+import dev.golddiggerapi.expenditure.domain.ExpenditureStatus;
+
+import java.time.LocalDateTime;
+
+public record ExpenditureResponse(
+        Long id,
+        Long amount,
+        String memo,
+        LocalDateTime expenditureDateTime,
+        ExpenditureStatus expenditureStatus,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static ExpenditureResponse toResponse(Expenditure expenditure) {
+        return new ExpenditureResponse(
+                expenditure.getId(),
+                expenditure.getAmount(),
+                expenditure.getMemo(),
+                expenditure.getExpenditureDateTime(),
+                expenditure.getExpenditureStatus(),
+                expenditure.getCreatedAt(),
+                expenditure.getUpdatedAt());
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureUpdateRequest.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureUpdateRequest.java
@@ -1,0 +1,19 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record ExpenditureUpdateRequest(
+        @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:00")
+        @NotBlank
+        String dateTime,
+        @Min(value = 0)
+        Long amount,
+        @NotNull
+        String memo,
+        @NotBlank
+        Long categoryId
+) {
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/domain/Expenditure.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/domain/Expenditure.java
@@ -1,13 +1,18 @@
 package dev.golddiggerapi.expenditure.domain;
 
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureRequest;
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureUpdateRequest;
 import dev.golddiggerapi.user.domain.User;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @NoArgsConstructor
 @Entity
+@Getter
 @Table(name = "expenditure")
 public class Expenditure {
 
@@ -16,6 +21,10 @@ public class Expenditure {
     private Long id;
 
     private Long amount;
+
+    private String memo;
+
+    private LocalDateTime expenditureDateTime;
 
     @Enumerated(EnumType.STRING)
     private ExpenditureStatus expenditureStatus;
@@ -31,4 +40,37 @@ public class Expenditure {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "expenditure_category_id")
     private ExpenditureCategory expenditureCategory;
+
+    public Expenditure(User user, ExpenditureCategory category, ExpenditureRequest request) {
+        this.amount = request.amount();
+        this.memo = request.memo();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:00");
+        this.expenditureDateTime = LocalDateTime.parse(request.dateTime(), formatter);
+        this.expenditureStatus = ExpenditureStatus.INCLUDED;
+        this.user = user;
+        this.expenditureCategory = category;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void update(ExpenditureUpdateRequest request, ExpenditureCategory category) {
+        this.amount = request.amount();
+        this.memo = request.memo();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:00");
+        this.expenditureDateTime = LocalDateTime.parse(request.dateTime(), formatter);
+        if(!isInputCategorySameAsThisCategory(category)) {
+            this.expenditureCategory = category;
+        }
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    private boolean isInputCategorySameAsThisCategory(ExpenditureCategory category) {
+        return this.expenditureCategory == category;
+    }
+
+    public void exclude() {
+        if(expenditureStatus == ExpenditureStatus.INCLUDED) {
+            this.expenditureStatus = ExpenditureStatus.EXCLUDED;
+        }
+    }
 }

--- a/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepository.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepository.java
@@ -1,9 +1,13 @@
 package dev.golddiggerapi.expenditure.repository;
 
 import dev.golddiggerapi.expenditure.domain.Expenditure;
+import dev.golddiggerapi.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface ExpenditureRepository extends JpaRepository<Expenditure, Long> {
+public interface ExpenditureRepository extends JpaRepository<Expenditure, Long>, ExpenditureRepositoryCustom{
+    Optional<Expenditure> findExpenditureByIdAndUser(Long id, User user);
 }

--- a/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustom.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustom.java
@@ -1,0 +1,16 @@
+package dev.golddiggerapi.expenditure.repository;
+
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureByUserRequest;
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureCategoryAndAmountResponse;
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureMemoAndAmountResponse;
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureMinAndMax;
+import dev.golddiggerapi.user.domain.User;
+
+import java.util.List;
+
+public interface ExpenditureRepositoryCustom {
+    List<ExpenditureCategoryAndAmountResponse> statisticExpenditureCategoryAndAmount(User user, ExpenditureByUserRequest request);
+    List<ExpenditureMemoAndAmountResponse> getExpendituresMemoAndAmountByCondition(User user, ExpenditureByUserRequest request);
+    ExpenditureMinAndMax getExpenditureMinAndMaxByUser(User user, ExpenditureByUserRequest request);
+    Long getExpendituresSumByUserAndCondition(User user, ExpenditureByUserRequest request);
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustomImpl.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustomImpl.java
@@ -1,0 +1,88 @@
+package dev.golddiggerapi.expenditure.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dev.golddiggerapi.expenditure.controller.dto.*;
+import dev.golddiggerapi.expenditure.domain.ExpenditureStatus;
+import dev.golddiggerapi.expenditure.domain.QExpenditure;
+import dev.golddiggerapi.expenditure.domain.QExpenditureCategory;
+import dev.golddiggerapi.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ExpenditureRepositoryCustomImpl implements ExpenditureRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    QExpenditure expenditure = QExpenditure.expenditure;
+    QExpenditureCategory expenditureCategory = QExpenditureCategory.expenditureCategory;
+
+    @Override
+    public List<ExpenditureCategoryAndAmountResponse> statisticExpenditureCategoryAndAmount(User user, ExpenditureByUserRequest request) {
+        if (request.getCategoryId() != null) {
+            return queryFactory.select(new QExpenditureCategoryAndAmountResponse(expenditureCategory.id, expenditureCategory.name, expenditure.amount.sum()))
+                    .from(expenditure)
+                    .where(expenditure.user.eq(user)
+                            .and(expenditureCategory.id.eq(request.getCategoryId()))
+                            .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L)))
+                            .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
+                    .fetch();
+        }
+        return queryFactory.select(new QExpenditureCategoryAndAmountResponse(expenditureCategory.id, expenditureCategory.name, expenditure.amount.sum()))
+                .from(expenditure)
+                .where(expenditure.user.eq(user)
+                        .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L)))
+                        .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
+                .groupBy(expenditureCategory.id)
+                .fetch();
+    }
+
+    @Override
+    public ExpenditureMinAndMax getExpenditureMinAndMaxByUser(User user, ExpenditureByUserRequest request) {
+        if (request.getCategoryId() != null) {
+            return queryFactory.select(new QExpenditureMinAndMax(expenditure.amount.min(), expenditure.amount.max()))
+                    .from(expenditure)
+                    .where(expenditure.user.eq(user)
+                            .and(expenditureCategory.id.eq(request.getCategoryId()))
+                            .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L)))
+                            .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
+                    .fetchFirst();
+        }
+        return queryFactory.select(new QExpenditureMinAndMax(expenditure.amount.min(), expenditure.amount.max()))
+                .from(expenditure)
+                .where(expenditure.user.eq(user)
+                        .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L)))
+                        .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
+                .fetchFirst();
+    }
+
+    @Override
+    public List<ExpenditureMemoAndAmountResponse> getExpendituresMemoAndAmountByCondition(User user, ExpenditureByUserRequest request) {
+        if(request.getCategoryId() != null) {
+            return queryFactory.select(new QExpenditureMemoAndAmountResponse(expenditureCategory.id, expenditure.memo, expenditure.amount))
+                    .from(expenditure)
+                    .where(expenditure.user.eq(user)
+                            .and(expenditureCategory.id.eq(request.getCategoryId()))
+                            .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L))))
+                    .fetch();
+        }
+        return queryFactory.select(new QExpenditureMemoAndAmountResponse(expenditureCategory.id, expenditure.memo, expenditure.amount))
+                .from(expenditure)
+                .where(expenditure.user.eq(user)
+                        .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L))))
+                .fetch();
+    }
+
+    @Override
+    public Long getExpendituresSumByUserAndCondition(User user, ExpenditureByUserRequest request) {
+        return queryFactory.select(expenditure.amount.sum())
+                .from(expenditure)
+                .where(expenditure.user.eq(user)
+                        .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L)))
+                        .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
+                .fetchFirst();
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/service/ExpenditureService.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/service/ExpenditureService.java
@@ -1,0 +1,116 @@
+package dev.golddiggerapi.expenditure.service;
+
+import dev.golddiggerapi.expenditure.controller.dto.*;
+import dev.golddiggerapi.expenditure.domain.Expenditure;
+import dev.golddiggerapi.expenditure.domain.ExpenditureCategory;
+import dev.golddiggerapi.expenditure.repository.ExpenditureCategoryRepository;
+import dev.golddiggerapi.expenditure.repository.ExpenditureRepository;
+import dev.golddiggerapi.user.domain.User;
+import dev.golddiggerapi.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ExpenditureService {
+
+    private final ExpenditureRepository expenditureRepository;
+    private final UserRepository userRepository;
+    private final ExpenditureCategoryRepository expenditureCategoryRepository;
+
+    @Transactional
+    public String createExpenditure(String accountName, Long categoryId, ExpenditureRequest request) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+
+        ExpenditureCategory category = expenditureCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("no category id in db"));
+
+        Expenditure expenditure = new Expenditure(user, category, request);
+        expenditureRepository.save(expenditure);
+        return "created";
+    }
+
+    @Transactional
+    public String updateExpenditure(String accountName, Long expenditureId, ExpenditureUpdateRequest request) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+
+        ExpenditureCategory category = expenditureCategoryRepository.findById(request.categoryId())
+                .orElseThrow(() -> new IllegalArgumentException("no category id in db"));
+
+        Expenditure expenditure = expenditureRepository.findById(expenditureId)
+                .orElseThrow(() -> new IllegalArgumentException("no expenditure in db"));
+
+        expenditure.update(request, category);
+        return "updated";
+    }
+
+    public ExpenditureResponse getExpenditure(String accountName, Long expenditureId) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+
+        Expenditure expenditure = expenditureRepository.findById(expenditureId)
+                .orElseThrow(() -> new IllegalArgumentException("no expenditure in db"));
+
+        return ExpenditureResponse.toResponse(expenditure);
+    }
+
+    public ExpenditureByUserResponse getExpendituresByUser(String accountName, ExpenditureByUserRequest request) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+        // 카테고리 ID가 없을 경우 : 전체 카테고리 목록 조회
+        List<ExpenditureCategoryAndAmountResponse> response = expenditureRepository.statisticExpenditureCategoryAndAmount(user, request);
+        // 각 지출 메모와 액수를 조회한다.
+        List<ExpenditureMemoAndAmountResponse> memoAndAmount = expenditureRepository.getExpendituresMemoAndAmountByCondition(user, request);
+        if (!hasCategoryId(request)) {
+            Long sum = expenditureRepository.getExpendituresSumByUserAndCondition(user, request);
+            if (hasRequestMinAndMax(request)) {
+                ExpenditureMinAndMax minAndMax = expenditureRepository.getExpenditureMinAndMaxByUser(user, request);
+                return new ExpenditureByUserResponse(sum, minAndMax, response, memoAndAmount);
+            }
+            return new ExpenditureByUserResponse(sum, null, response, memoAndAmount);
+        }
+        // 카테고리 ID가 있을 경우 : 특정 카테고리 목록 조회
+        if (hasRequestMinAndMax(request)) {
+            ExpenditureMinAndMax minAndMax = expenditureRepository.getExpenditureMinAndMaxByUser(user, request);
+            return new ExpenditureByUserResponse(response.get(0).sum(), minAndMax, response, memoAndAmount);
+        }
+        return new ExpenditureByUserResponse(response.get(0).sum(), null, response, memoAndAmount);
+    }
+
+    private boolean hasCategoryId(ExpenditureByUserRequest request) {
+        return request.getCategoryId() != null;
+    }
+
+    private boolean hasRequestMinAndMax(ExpenditureByUserRequest request) {
+        return request.getHasMinAndMax();
+    }
+
+    @Transactional
+    public String deleteExpenditure(String accountName, Long expenditureId) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+
+        Expenditure expenditure = expenditureRepository.findExpenditureByIdAndUser(expenditureId, user)
+                .orElseThrow(() -> new IllegalArgumentException("no expenditure in db or no auth to delete"));
+
+        expenditureRepository.delete(expenditure);
+        return "deleted";
+    }
+
+    @Transactional
+    public String excludeExpenditure(String accountName, Long expenditureId) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+
+        Expenditure expenditure = expenditureRepository.findExpenditureByIdAndUser(expenditureId, user)
+                .orElseThrow(() -> new IllegalArgumentException("no expenditure in db or no auth to delete"));
+
+        expenditure.exclude();
+        return "excluded";
+    }
+}

--- a/src/main/java/dev/golddiggerapi/user/controller/UserBudgetController.java
+++ b/src/main/java/dev/golddiggerapi/user/controller/UserBudgetController.java
@@ -6,6 +6,7 @@ import dev.golddiggerapi.user.service.UserBudgetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -17,7 +18,7 @@ public class UserBudgetController {
 
     @PostMapping("/{categoryId}")
     public ResponseEntity<String> createUserBudget(@PathVariable Long categoryId,
-                                                   @RequestBody UserBudgetCreateRequest request) {
+                                                   @Validated @RequestBody UserBudgetCreateRequest request) {
         // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
         String mockAccountName = "abc";
         String res = userBudgetService.createUserBudget(mockAccountName, categoryId, request);
@@ -26,7 +27,7 @@ public class UserBudgetController {
 
     @PatchMapping("/{userBudgetId}")
     public ResponseEntity<String> updateUserBudget(@PathVariable Long userBudgetId,
-                                                   @RequestBody UserBudgetUpdateRequest request) {
+                                                   @Validated @RequestBody UserBudgetUpdateRequest request) {
         // SecurityContextHolder 에서 정보를 꺼내서 사용할 예정입니다.
         String mockAccountName = "abc";
         String res = userBudgetService.updateUserBudget(mockAccountName, userBudgetId, request);

--- a/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
+++ b/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
@@ -43,11 +43,10 @@ public class UserBudget {
     public void update(UserBudgetUpdateRequest request, ExpenditureCategory category) {
         this.amount = request.amount();
         this.updatedAt = LocalDateTime.now();
-        // Input 카테고리가 같다면 pass 합니다.
-        if(isInputCategorySameAsThisCategory(category)) {
-            return;
+        // Input 카테고리가 같지않다면 수정합니다.
+        if(!isInputCategorySameAsThisCategory(category)) {
+            this.expenditureCategory = category;
         }
-        this.expenditureCategory = category;
     }
 
     private boolean isInputCategorySameAsThisCategory(ExpenditureCategory category) {


### PR DESCRIPTION
# [Feat] 지출 CRUD (API)

## 🔥 Issue Number
#10

## 📄 Summary
- 지출 생성, 수정, 읽기(상세), 읽기(목록), 삭제, 합계제외 API 구현 및 테스트 완료
- 읽기(목록) 은 기능이 세분화 되어있습니다.
  - querydsl 사용 및 요구사항 응답구조를 만들기 위해 QueryProjection으로 커스텀 QFile을 만들어서 사용
  - 필수적으로 @RequestParam에 start, end (LocalDate)을 넣도록 엔드포인트 설정
  - 모든 목록 조회 기간으로 조회하도록 설계
  - request condition : 카테고리 id가 null이 아니라면 해당 카테고리로 조회, null 이라면 모든 카테고리 조회
    - hasMinAndMax : 기본적으로 false로 설정 requestParam에 true로 들어온다면 결과에 최소 & 최대액수 응답하도록 구현
  - 지출 총합은 모든 경우 응답에 포함
  - param 조합에따라 카테고리별 또는 전체 / MinAndMax를 포함할지 안할지 / 기간 설정 가능
- 합계제외 : 상태를 EXCLUDED로 변경

## 👨‍💻️ References

## 🙋‍ To reviewers