### PR TITLE
[Feat] 오늘 지출 안내 API

### DIFF
--- a/src/main/java/dev/golddiggerapi/expenditure/controller/ExpenditureController.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/ExpenditureController.java
@@ -73,6 +73,13 @@ public class ExpenditureController {
         return ResponseEntity.ok().body(res);
     }
 
+    @GetMapping("/today")
+    public ResponseEntity<ExpenditureByTodayResponse> getExpenditureByToday() {
+        String mockAccountName = "abc";
+        ExpenditureByTodayResponse res = expenditureService.getExpenditureByToday(mockAccountName);
+        return ResponseEntity.ok().body(res);
+    }
+
     // 유저 카테고리별 지출 평균 비율 (유저 지출 비율 기준으로 통계)
     @GetMapping("/avg-ratio")
     public ResponseEntity<List<UserExpenditureAvgRatioByCategoryStatisticResponse>> statisticExpenditureAvgRatioByCategory() {

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureAnalyze.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureAnalyze.java
@@ -1,0 +1,7 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+public record ExpenditureAnalyze(
+        Long reasonableExpenditureSum,
+        Long risk
+) {
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByTodayByCategoryStatisticsResponse.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByTodayByCategoryStatisticsResponse.java
@@ -1,0 +1,20 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+public record ExpenditureByTodayByCategoryStatisticsResponse(
+        Long categoryId,
+        String name,
+        Long expenditureSum,
+        Long reasonableExpenditureSum,
+        String risk
+) {
+
+    public static ExpenditureByTodayByCategoryStatisticsResponse toResponse(ExpenditureCategoryAndAmountResponse response, ExpenditureAnalyze analyze) {
+        return new ExpenditureByTodayByCategoryStatisticsResponse(
+                response.categoryId(),
+                response.name(),
+                response.sum(),
+                analyze.reasonableExpenditureSum(),
+                String.valueOf(analyze.risk()) + '%'
+        );
+    }
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByTodayResponse.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureByTodayResponse.java
@@ -1,0 +1,10 @@
+package dev.golddiggerapi.expenditure.controller.dto;
+
+import java.util.List;
+
+public record ExpenditureByTodayResponse(
+        Long expenditureSum,
+        Long reasonableExpenditureSum,
+        List<ExpenditureByTodayByCategoryStatisticsResponse> expenditureByTodayByCategoryStatisticsResponses
+) {
+}

--- a/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustom.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustom.java
@@ -19,4 +19,6 @@ public interface ExpenditureRepositoryCustom {
     Long getExpendituresSumByUserAndCondition(User user, ExpenditureByUserRequest request);
 
     List<UserExpenditureAvgRatioByCategoryStatisticResponse> statisticAvgRatioByCategory();
+
+    List<ExpenditureCategoryAndAmountResponse> statisticExpenditureCategoryAndAmountByTodayByUser(User user);
 }

--- a/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustomImpl.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustomImpl.java
@@ -11,6 +11,8 @@ import dev.golddiggerapi.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 
 @Repository
@@ -38,6 +40,17 @@ public class ExpenditureRepositoryCustomImpl implements ExpenditureRepositoryCus
                 .from(expenditure)
                 .where(expenditure.user.eq(user)
                         .and(expenditure.expenditureDateTime.between(request.getStart(), request.getEnd().plusDays(1L)))
+                        .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
+                .groupBy(expenditureCategory.id)
+                .fetch();
+    }
+
+    @Override
+    public List<ExpenditureCategoryAndAmountResponse> statisticExpenditureCategoryAndAmountByTodayByUser(User user) {
+        return queryFactory.select(new QExpenditureCategoryAndAmountResponse(expenditureCategory.id, expenditureCategory.name, expenditure.amount.sum()))
+                .from(expenditure)
+                .where(expenditure.user.eq(user)
+                        .and(expenditure.expenditureDateTime.between(LocalDate.now().atStartOfDay(), LocalDate.now().atTime(LocalTime.MAX)))
                         .and(expenditure.expenditureStatus.eq(ExpenditureStatus.INCLUDED)))
                 .groupBy(expenditureCategory.id)
                 .fetch();

--- a/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
+++ b/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
@@ -1,5 +1,6 @@
 package dev.golddiggerapi.user.domain;
 
+import dev.golddiggerapi.expenditure.controller.dto.ExpenditureAnalyze;
 import dev.golddiggerapi.expenditure.domain.ExpenditureCategory;
 import dev.golddiggerapi.user.controller.dto.UserBudgetCreateRequest;
 import dev.golddiggerapi.user.controller.dto.UserBudgetUpdateRequest;
@@ -70,5 +71,11 @@ public class UserBudget {
 
     private boolean isInputCategorySameAsThisCategory(ExpenditureCategory category) {
         return this.expenditureCategory == category;
+    }
+
+    public ExpenditureAnalyze analyzeReasonableExpenditureSumAndRisk(Long expenditureSum) {
+        Long reasonableExpenditureSum = this.amount / YearMonth.now().lengthOfMonth();
+        Long risk = (expenditureSum / reasonableExpenditureSum) * 100;
+        return new ExpenditureAnalyze(reasonableExpenditureSum, risk);
     }
 }

--- a/src/main/java/dev/golddiggerapi/user/repository/UserBudgetRepository.java
+++ b/src/main/java/dev/golddiggerapi/user/repository/UserBudgetRepository.java
@@ -7,8 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserBudgetRepository extends JpaRepository<UserBudget, Long>, UserBudgetRepositoryCustom {
     boolean existsByUserAndExpenditureCategoryAndPlannedMonth(User user, ExpenditureCategory category, LocalDateTime plannedMonth);
+    List<UserBudget> findUserBudgetsByUserAndPlannedMonth(User user, LocalDateTime plannedMonth);
+    Optional<UserBudget> findUserBudgetByUserAndExpenditureCategory_IdAndPlannedMonth(User user, Long categoryId, LocalDateTime plannedMonth);
 }


### PR DESCRIPTION
# [Feat] 오늘 지출 안내 API

## 🔥 Issue Number
#15

## 📄 Summary
- 아래의 응답구조를 만들어서 지출안내 API 요구사항 구현
```json
{
    "expenditureSum": 40000,
    "reasonableExpenditureSum": 4500,
    "expenditureByTodayByCategoryStatisticsResponses": [
        {
            "categoryId": 1,
            "name": "식비",
            "expenditureSum": 30000,
            "reasonableExpenditureSum": 666,
            "risk": "4500%"
        },
        {
            "categoryId": 2,
            "name": "쇼핑",
            "expenditureSum": 10000,
            "reasonableExpenditureSum": 500,
            "risk": "2000%"
        }
    ]
}
```
- 유저의 카테고리별 지출 통계 쿼리 구현 (오늘기간)
- 유저의 이달의 예산 리스트 조회 : 지출 총액 응답 + 총예산 대비 적정 하루 지출 금액 응답
- 유저의 카테고리별 지출 통계 리스트에서 스트림 map을 사용
  - 유저, 카테고리 ID, 이번달의 예산을 조회하여 유저 예산에서 예산 대비 지출 분석
  - 지출분석 record : ExpenditureAnalyze(적정지출액, 위험도)
  - 기존 카테고리별 지출 통계리스트 + 분석을 반환하도록 구현
- 유저가 예산설정을 하지 않은 경우 적정지출액, 위헙도 0반환

## 👨‍💻️ References

## 🙋‍ To reviewers