### PR TITLE
[Feat] 지출 통계 (API)

### DIFF
--- a/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustom.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/repository/ExpenditureRepositoryCustom.java
@@ -1,12 +1,10 @@
 package dev.golddiggerapi.expenditure.repository;
 
-import dev.golddiggerapi.expenditure.controller.dto.ExpenditureByUserRequest;
-import dev.golddiggerapi.expenditure.controller.dto.ExpenditureCategoryAndAmountResponse;
-import dev.golddiggerapi.expenditure.controller.dto.ExpenditureMemoAndAmountResponse;
-import dev.golddiggerapi.expenditure.controller.dto.ExpenditureMinAndMax;
-import dev.golddiggerapi.expenditure.controller.dto.UserExpenditureAvgRatioByCategoryStatisticResponse;
+import dev.golddiggerapi.expenditure.controller.dto.*;
+import dev.golddiggerapi.statistics.controller.dto.ConsumptionRateByCategoryStatistics;
 import dev.golddiggerapi.user.domain.User;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ExpenditureRepositoryCustom {
@@ -21,4 +19,8 @@ public interface ExpenditureRepositoryCustom {
     List<UserExpenditureAvgRatioByCategoryStatisticResponse> statisticAvgRatioByCategory();
 
     List<ExpenditureCategoryAndAmountResponse> statisticExpenditureCategoryAndAmountByTodayByUser(User user);
+
+    List<ConsumptionRateByCategoryStatistics> getExpenditureConsumptionRateByCategoryCompareToPreviousMonth();
+
+    Long sumAmountByExpenditureDateTimeBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/dev/golddiggerapi/statistics/controller/StatisticsController.java
+++ b/src/main/java/dev/golddiggerapi/statistics/controller/StatisticsController.java
@@ -1,0 +1,24 @@
+package dev.golddiggerapi.statistics.controller;
+
+import dev.golddiggerapi.statistics.controller.dto.ExpenditureStatisticsResponse;
+import dev.golddiggerapi.statistics.service.StatisticsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping("/expenditures/consumption-rate")
+    public ResponseEntity<ExpenditureStatisticsResponse> getExpenditureStatistics() {
+        String mockAccountName = "abc";
+        ExpenditureStatisticsResponse res = statisticsService.getExpenditureStatistics(mockAccountName);
+        return ResponseEntity.ok().body(res);
+    }
+}

--- a/src/main/java/dev/golddiggerapi/statistics/controller/dto/ConsumptionRateByCategoryResponse.java
+++ b/src/main/java/dev/golddiggerapi/statistics/controller/dto/ConsumptionRateByCategoryResponse.java
@@ -1,0 +1,15 @@
+package dev.golddiggerapi.statistics.controller.dto;
+
+public record ConsumptionRateByCategoryResponse(
+        Long categoryId,
+        String name,
+        String consumptionRate
+) {
+    public static ConsumptionRateByCategoryResponse toResponse(ConsumptionRateByCategoryStatistics consumptionRateByCategoryStatistics) {
+        return new ConsumptionRateByCategoryResponse(
+                consumptionRateByCategoryStatistics.categoryId(),
+                consumptionRateByCategoryStatistics.name(),
+                String.valueOf(consumptionRateByCategoryStatistics.consumptionRate()) + '%'
+        );
+    }
+}

--- a/src/main/java/dev/golddiggerapi/statistics/controller/dto/ConsumptionRateByCategoryStatistics.java
+++ b/src/main/java/dev/golddiggerapi/statistics/controller/dto/ConsumptionRateByCategoryStatistics.java
@@ -1,0 +1,13 @@
+package dev.golddiggerapi.statistics.controller.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record ConsumptionRateByCategoryStatistics(
+        Long categoryId,
+        String name,
+        Long consumptionRate
+) {
+    @QueryProjection
+    public ConsumptionRateByCategoryStatistics {
+    }
+}

--- a/src/main/java/dev/golddiggerapi/statistics/controller/dto/ExpenditureStatisticsResponse.java
+++ b/src/main/java/dev/golddiggerapi/statistics/controller/dto/ExpenditureStatisticsResponse.java
@@ -1,0 +1,11 @@
+package dev.golddiggerapi.statistics.controller.dto;
+
+import java.util.List;
+
+public record ExpenditureStatisticsResponse(
+        String consumptionRateCompareToPreviousMonth,
+        String consumptionRateCompareToPreviousDay,
+        String consumptionRateCompareToOtherUsersConsumptionRate,
+        List<ConsumptionRateByCategoryResponse> consumptionRateByCategoryStatistics
+) {
+}

--- a/src/main/java/dev/golddiggerapi/statistics/service/StatisticsService.java
+++ b/src/main/java/dev/golddiggerapi/statistics/service/StatisticsService.java
@@ -1,0 +1,78 @@
+package dev.golddiggerapi.statistics.service;
+
+import dev.golddiggerapi.expenditure.repository.ExpenditureRepository;
+import dev.golddiggerapi.statistics.controller.dto.ConsumptionRateByCategoryResponse;
+import dev.golddiggerapi.statistics.controller.dto.ConsumptionRateByCategoryStatistics;
+import dev.golddiggerapi.statistics.controller.dto.ExpenditureStatisticsResponse;
+import dev.golddiggerapi.user.domain.User;
+import dev.golddiggerapi.user.repository.UserBudgetRepository;
+import dev.golddiggerapi.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private final UserRepository userRepository;
+    private final ExpenditureRepository expenditureRepository;
+    private final UserBudgetRepository userBudgetRepository;
+
+    public ExpenditureStatisticsResponse getExpenditureStatistics(String accountName) {
+        User user = userRepository.findUserByAccountName(accountName)
+                .orElseThrow(() -> new IllegalArgumentException("no account name in db"));
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startOfLastMonth = YearMonth.now().minusMonths(1).atDay(1).atStartOfDay();
+        LocalDateTime endOfLastMonth = now.minusMonths(1);
+        LocalDateTime startOfThisMonth = YearMonth.now().atDay(1).atStartOfDay();
+
+        // 지난 달 이 시점 대비 총액, 카테고리별 소비율 (얼마나 더 썼나?)
+        Long previousMonthTotalPrice = expenditureRepository.sumAmountByExpenditureDateTimeBetween(startOfLastMonth, endOfLastMonth);
+        Long thisMonthTotalPrice = expenditureRepository.sumAmountByExpenditureDateTimeBetween(startOfThisMonth, now);
+
+        BiFunction<Long, Long, String> executeRatingToStringFunction = (a, b) -> String.valueOf((b / a) * 100) + '%';
+
+        List<ConsumptionRateByCategoryStatistics> userBudgetConsumptionRateByCategoryCompareToPreviousMonth =
+                expenditureRepository.getExpenditureConsumptionRateByCategoryCompareToPreviousMonth();
+
+        List<ConsumptionRateByCategoryResponse> res = userBudgetConsumptionRateByCategoryCompareToPreviousMonth.stream()
+                .map(ConsumptionRateByCategoryResponse::toResponse)
+                .collect(Collectors.toList());
+        // 지난 요일 대비 소비율 (얼마나 더 썼나?)
+        // 현재 요일 & 현재 요일부터 7일 전의 요일
+        DayOfWeek nowDay = now.getDayOfWeek();
+        DayOfWeek previousDay = nowDay.minus(7);
+
+        // 현재 요일의 시작과 끝
+        LocalDateTime startOfToday = now.with(DayOfWeek.from(nowDay)).toLocalDate().atStartOfDay();
+        LocalDateTime endOfToday = now.with(DayOfWeek.from(nowDay)).toLocalDate().atTime(23, 59, 59, 59);
+
+        // 7일 전의 요일의 시작과 끝
+        LocalDateTime startOfPreviousDay = now.with(DayOfWeek.from(previousDay)).toLocalDate().atStartOfDay();
+        LocalDateTime endOfPreviousDay = now.with(DayOfWeek.from(previousDay)).toLocalDate().atTime(23, 59, 59, 59);
+
+        Long previousDayTotalPrice = expenditureRepository.sumAmountByExpenditureDateTimeBetween(startOfPreviousDay, endOfPreviousDay);
+        Long thisDayTotalPrice = expenditureRepository.sumAmountByExpenditureDateTimeBetween(startOfToday, endOfToday);
+
+        // 다른 유저 대비 소비율 (오늘 기준 다른 유저가 예산 대비 사용한 평균 비율 대비 나의 비율)
+        Long consumptionRateCompareByOtherUsers = userBudgetRepository.getUserBudgetConsumptionRateByUsers(user);
+        Long consumptionRateByUser = userBudgetRepository.getUserBudgetConsumptionRateByUser(user);
+        log.info("users={} me={}", consumptionRateCompareByOtherUsers, consumptionRateByUser);
+        return new ExpenditureStatisticsResponse(
+                executeRatingToStringFunction.apply(previousMonthTotalPrice, thisMonthTotalPrice),
+                executeRatingToStringFunction.apply(previousDayTotalPrice, thisDayTotalPrice),
+                executeRatingToStringFunction.apply(consumptionRateCompareByOtherUsers, consumptionRateByUser),
+                res
+        );
+    }
+}

--- a/src/main/java/dev/golddiggerapi/user/repository/UserBudgetRepositoryCustom.java
+++ b/src/main/java/dev/golddiggerapi/user/repository/UserBudgetRepositoryCustom.java
@@ -10,4 +10,8 @@ public interface UserBudgetRepositoryCustom {
     List<UserBudgetAvgRatioByCategoryStatisticResponse> statisticUserBudgetAvgRatioByCategory();
 
     List<UserBudgetCategoryAndAvailableExpenditure> getAvailableUserBudgetByCategoryByToday(User user);
+
+    Long getUserBudgetConsumptionRateByUsers(User user);
+
+    Long getUserBudgetConsumptionRateByUser(User user);
 }

--- a/src/main/java/dev/golddiggerapi/user/repository/UserBudgetRepositoryCustomImpl.java
+++ b/src/main/java/dev/golddiggerapi/user/repository/UserBudgetRepositoryCustomImpl.java
@@ -73,4 +73,32 @@ public class UserBudgetRepositoryCustomImpl implements UserBudgetRepositoryCusto
                 .orderBy(expenditureCategory.id.asc())
                 .fetch();
     }
+
+    @Override
+    public Long getUserBudgetConsumptionRateByUsers(User user) {
+        Long result = queryFactory.select(expenditure.amount.sum().divide(
+                        JPAExpressions.select(userBudget.amount.sum())
+                                .from(userBudget)
+                                .where(userBudget.user.ne(user))
+                ).multiply(100))
+                .from(expenditure)
+                .where(expenditure.expenditureDateTime.between(YearMonth.now().atDay(1).atStartOfDay(), LocalDateTime.now())
+                        .and(expenditure.user.ne(user)))
+                .fetchFirst();
+        return result != null ? result : 1L;
+    }
+
+    @Override
+    public Long getUserBudgetConsumptionRateByUser(User user) {
+        Long result = queryFactory.select(expenditure.amount.sum().divide(
+                        JPAExpressions.select(userBudget.amount.sum())
+                                .from(userBudget)
+                                .where(userBudget.user.eq(user))
+                ).multiply(100))
+                .from(expenditure)
+                .where(expenditure.expenditureDateTime.between(YearMonth.now().atDay(1).atStartOfDay(), LocalDateTime.now())
+                        .and(expenditure.user.eq(user)))
+                .fetchFirst();
+        return result != null ? result : 1L;
+    }
 }


### PR DESCRIPTION
# [Feat] 지출 통계 (API)

## 🔥 Issue Number
#19 

## 📄 Summary
- 지날 달 대비 총액, 카테고리별 소비율 (지출액 / 설정예산)
  - 카테고리별 소비율은  ConsumptionRateByCategoryResponse라는 객체 리스트로 구현
  - 쿼리에 기간을 설정해서 오늘이 10일차 라면, 지난달 10일차 까지의 데이터를 대상으로 비교
- 지난 요일 대비 소비율
  - 오늘이 월요일 이라면 지난 월요일 에 소비한 모든 기록 대비 소비율 조회 구현
  - 사용자 기준이 아닌 모든 사용자의 총액 기준
- 다른 유저 대비 소비율
  - 이달의 설정 예산기준으로 대비 기준 설정
  - 다른 유저들의 이달 소비 총합 / 다른 유저들의 이달 예산 총합
  - 유저의 이달 소비 총합 / 유저의 이달 예산 총합
  - 둘을 비교하여 유저가 얼마나 덜 또는 더 소비했는지 조회 

## 👨‍💻️ References

## 🙋‍ To reviewers