### PR TITLE
[Feat] 분산락, 낙관적락을 활용한 동시성 제어

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.24.3'
 
     //Swagger
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.1.0'

--- a/src/main/java/dev/golddiggerapi/config/RedisConfig.java
+++ b/src/main/java/dev/golddiggerapi/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package dev.golddiggerapi.config;
 
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -56,4 +59,13 @@ public class RedisConfig {
                 .build();
     }
 
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port)
+                .setConnectionMinimumIdleSize(5)
+                .setConnectionPoolSize(200);
+        return Redisson.create(config);
+    }
 }

--- a/src/main/java/dev/golddiggerapi/exception/CustomErrorCode.java
+++ b/src/main/java/dev/golddiggerapi/exception/CustomErrorCode.java
@@ -21,7 +21,8 @@ public enum CustomErrorCode {
     INVALID_PARAMETER_DATE_NONE_SERVICE_DAY(HttpStatus.BAD_REQUEST, "Parameter's date includes none service day"),
     INVALID_PARAMETER_START_DATE(HttpStatus.BAD_REQUEST, "Parameter's start date can't after end"),
     INVALID_EXPENDITURES_GET_DURATION(HttpStatus.BAD_REQUEST, "Get Expenditures duration can't up to 30days"),
-    INVALID_PARAMETER_YEAR_BEFORE_NOW(HttpStatus.BAD_REQUEST, "Year can't before now");
+    INVALID_PARAMETER_YEAR_BEFORE_NOW(HttpStatus.BAD_REQUEST, "Year can't before now"),
+    CANT_GET_LOCK(HttpStatus.LOCKED, "At the same time, can't make excessive requests");
 
     private final HttpStatus status;
 

--- a/src/main/java/dev/golddiggerapi/expenditure/domain/Expenditure.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/domain/Expenditure.java
@@ -25,6 +25,9 @@ public class Expenditure {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     private Long amount;
 
     private String memo;

--- a/src/main/java/dev/golddiggerapi/global/util/service/TransactionService.java
+++ b/src/main/java/dev/golddiggerapi/global/util/service/TransactionService.java
@@ -1,0 +1,15 @@
+package dev.golddiggerapi.global.util.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.function.Supplier;
+
+@Service
+public class TransactionService {
+
+    @Transactional
+    public <T> void executeAsTransactional(Supplier<T> supplier) {
+        supplier.get();
+    }
+}

--- a/src/main/java/dev/golddiggerapi/global/util/strategy/RedissonLockContext.java
+++ b/src/main/java/dev/golddiggerapi/global/util/strategy/RedissonLockContext.java
@@ -1,0 +1,31 @@
+package dev.golddiggerapi.global.util.strategy;
+
+import dev.golddiggerapi.exception.CustomErrorCode;
+import dev.golddiggerapi.exception.detail.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedissonLockContext {
+
+    private final RedissonClient redissonClient;
+
+    public void executeLock(String username, RedissonLockStrategy strategy) {
+        RLock lock = redissonClient.getLock(username);
+        try {
+            // waitTime: 락 대기시간, leaseTime: 해당 시간이 지나면 락 해제
+            boolean available = lock.tryLock(0, 1, TimeUnit.SECONDS);
+            if(!available) {
+                throw new ApiException(CustomErrorCode.CANT_GET_LOCK);
+            }
+            strategy.call();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/dev/golddiggerapi/global/util/strategy/RedissonLockStrategy.java
+++ b/src/main/java/dev/golddiggerapi/global/util/strategy/RedissonLockStrategy.java
@@ -1,0 +1,6 @@
+package dev.golddiggerapi.global.util.strategy;
+
+@FunctionalInterface
+public interface RedissonLockStrategy {
+    void call();
+}

--- a/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
+++ b/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
@@ -24,6 +24,9 @@ public class UserBudget {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
     private Long amount;
 
     @Column(name = "planned_year_month")


### PR DESCRIPTION
# [Feat] 분산락, 낙관적락을 활용한 동시성 제어

## 🔥 Issue Number
#42 

## 📄 Summary
- Redisson 의존성 추가
- 락을 획득한 1개의 스레드만 트랜잭션을 적용하도록 설정
- TransactionService (트랜잭션 적용 함수 - supplier)
- 지출, 유저예산, 추천 유저예산 생성시 분산락 적용 (JPA @Version)
- 지출, 유저예산 업데이트시 낙관적락 적용 (ex 실수 동시클릭)

## 👨‍💻️ References

## 🙋‍ To reviewers