### PR TITLE
[Feat] 유저 예산 카테고리별 비율 통계 쿼리 캐싱 & 스케줄링

### DIFF
--- a/src/main/java/dev/golddiggerapi/user/controller/dto/UserBudgetUpdateRequest.java
+++ b/src/main/java/dev/golddiggerapi/user/controller/dto/UserBudgetUpdateRequest.java
@@ -3,7 +3,7 @@ package dev.golddiggerapi.user.controller.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "유저예산 수정 요청 DTO")
 public record UserBudgetUpdateRequest(
@@ -23,13 +23,13 @@ public record UserBudgetUpdateRequest(
         Integer month,
 
         @Schema(description = "수정 카테고리 ID", example = "2")
-        @NotBlank
+        @NotNull
         Long categoryId
 ) {
     public UserBudgetUpdateRequest(@Min(value = 0) Long amount,
                                    Integer year,
                                    @Min(1) @Max(12) Integer month,
-                                   @NotBlank Long categoryId) {
+                                   @NotNull Long categoryId) {
         this.amount = amount;
         this.year = year;
         this.month = month;

--- a/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
+++ b/src/main/java/dev/golddiggerapi/user/domain/UserBudget.java
@@ -86,4 +86,8 @@ public class UserBudget {
         Long risk = (expenditureSum / reasonableExpenditureSum) * 100;
         return new ExpenditureAnalyze(reasonableExpenditureSum, risk);
     }
+
+    public boolean isCategoryIdSameAsRequestCategoryId(UserBudgetUpdateRequest request) {
+        return this.expenditureCategory.getId().equals(request.categoryId());
+    }
 }

--- a/src/main/java/dev/golddiggerapi/user/service/UserBudgetService.java
+++ b/src/main/java/dev/golddiggerapi/user/service/UserBudgetService.java
@@ -15,6 +15,8 @@ import dev.golddiggerapi.user.domain.UserBudget;
 import dev.golddiggerapi.user.repository.UserBudgetRepository;
 import dev.golddiggerapi.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,6 +69,12 @@ public class UserBudgetService {
                 .orElseThrow(() -> new ApiException(CustomErrorCode.CATEGORY_NOT_FOUND_DB));
 
         // 유저 예산의 카테고리, 년, 월, 예산총액을 수정할 수 있다.
+        // 카테고리 ID가 같은 경우는 예외처리 검증 X
+        if (userBudget.isCategoryIdSameAsRequestCategoryId(request)) {
+            userBudget.update(request, category);
+            return "updated";
+        }
+
         userBudget.update(request, category);
         // 업데이트후 중복된 월 and 카테고리 유저 예산이 DB에 있다면 예외처리한다.
         validateDuplicatedUserBudget(user, userBudget, category);
@@ -77,6 +85,12 @@ public class UserBudgetService {
         if (isExistsUserBudgetByCategoryAndYearMonth(user, category, userBudget.getPlannedYearMonth())) {
             throw new ApiException(CustomErrorCode.DUPLICATED_USER_BUDGET);
         }
+    }
+
+    @Scheduled(cron = "0 0 2 * * *")
+    @CachePut(value = "user-budget:avg-ratio:1:collections", cacheManager = "cacheManager")
+    public void cacheUserBudgetAvgRatioByCategoryStatistic() {
+        userBudgetRepository.statisticUserBudgetAvgRatioByCategory();
     }
 
     public List<UserBudgetRecommendation> getUserBudgetByRecommendation(Long budget) {


### PR DESCRIPTION
# [Feat] 유저 예산 카테고리별 비율 통계 쿼리 캐싱 & 스케줄링

## 🔥 Issue Number
#44

## 📄 Summary
- 새벽 2시 유저 예산 카테고리별 비율 통계 쿼리 캐싱 스케줄링
- CachePut으로 Value 갱신
- 기존 8.7sec -> 57ms 로 Latency 개선
- 불필요 DB/IO 개선

## 👨‍💻️ References

## 🙋‍ To reviewers