### PR TITLE
[Feat] 지출 일시 유효성 2차 검증 로직 추가 Dev to Production

### DIFF
--- a/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureRequest.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/controller/dto/ExpenditureRequest.java
@@ -8,8 +8,8 @@ import jakarta.validation.constraints.Size;
 
 @Schema(description = "지출 요청 DTO")
 public record ExpenditureRequest(
-        //'yyyy-MM-dd HH:00' 형식 1차 validation -> ssss-wm-ei 2m:00 으로
-        @Schema(description = "지출 일시", example = "2023-11-14 19:30")
+        //'yyyy-MM-dd HH:00' 형식 1차 validation
+        @Schema(description = "지출 일시", example = "2023-11-14 19:00")
         @Pattern(regexp = "\\d{4}-\\d{2}-\\d{2}\\s\\d{2}:00", message = "yyyy-MM-dd HH:00 형식이어야 합니다.")
         String dateTime,
 

--- a/src/main/java/dev/golddiggerapi/expenditure/domain/Expenditure.java
+++ b/src/main/java/dev/golddiggerapi/expenditure/domain/Expenditure.java
@@ -1,5 +1,7 @@
 package dev.golddiggerapi.expenditure.domain;
 
+import dev.golddiggerapi.exception.CustomErrorCode;
+import dev.golddiggerapi.exception.detail.ApiException;
 import dev.golddiggerapi.expenditure.controller.dto.ExpenditureRequest;
 import dev.golddiggerapi.expenditure.controller.dto.ExpenditureUpdateRequest;
 import dev.golddiggerapi.user.domain.User;
@@ -8,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.format.DateTimeFormatter;
 
 @NoArgsConstructor
@@ -56,11 +59,23 @@ public class Expenditure {
         this.memo = request.memo();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:00");
         this.expenditureDateTime = LocalDateTime.parse(request.dateTime(), formatter);
+        validateExpenditureDateTime(expenditureDateTime);
         this.expenditureStatus = ExpenditureStatus.INCLUDED;
         this.user = user;
         this.expenditureCategory = category;
         this.createdAt = LocalDateTime.now();
         this.updatedAt = LocalDateTime.now();
+    }
+
+    private void validateExpenditureDateTime(LocalDateTime time) {
+        LocalDateTime max = LocalDateTime.of(2050, Month.JANUARY, 1, 0, 0);
+        LocalDateTime min = LocalDateTime.of(2023, Month.JANUARY, 2, 0, 0);
+        if(time.isAfter(max)) {
+            throw new ApiException(CustomErrorCode.INVALID_PARAMETER_DATE_NONE_SERVICE_DAY);
+        }
+        if(time.isBefore(min)) {
+            throw new ApiException(CustomErrorCode.INVALID_PARAMETER_DATE_NONE_SERVICE_DAY);
+        }
     }
 
     public void update(ExpenditureUpdateRequest request, ExpenditureCategory category) {

--- a/src/test/java/dev/golddiggerapi/expenditure/domain/ExpenditureTest.java
+++ b/src/test/java/dev/golddiggerapi/expenditure/domain/ExpenditureTest.java
@@ -1,5 +1,6 @@
 package dev.golddiggerapi.expenditure.domain;
 
+import dev.golddiggerapi.exception.detail.ApiException;
 import dev.golddiggerapi.expenditure.controller.dto.ExpenditureRequest;
 import dev.golddiggerapi.expenditure.controller.dto.ExpenditureUpdateRequest;
 import dev.golddiggerapi.user.controller.dto.UserSignupRequest;
@@ -12,6 +13,7 @@ import java.time.Month;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ExpenditureTest {
 
@@ -29,6 +31,20 @@ class ExpenditureTest {
         category = new ExpenditureCategory(1L, "식비");
 
         expenditure = new Expenditure(user, category, request);
+    }
+
+    @Test
+    void create_expenditure_before_service_day_throw_exception() {
+        ExpenditureRequest request = new ExpenditureRequest("2023-01-01 23:00", 10_000L, "점심");
+        assertThatThrownBy(() -> new Expenditure(user, category, request))
+                .isInstanceOf(ApiException.class);
+    }
+
+    @Test
+    void create_expenditure_after_service_day_throw_exception() {
+        ExpenditureRequest request = new ExpenditureRequest("2050-01-01 01:00", 10_000L, "점심");
+        assertThatThrownBy(() -> new Expenditure(user, category, request))
+                .isInstanceOf(ApiException.class);
     }
 
     @Test


### PR DESCRIPTION
# [Feat] 지출 일시 유효성 2차 검증 로직 추가 Dev to Production

## 🔥 Issue Number

## 📄 Summary
- 지출 생성자에서 지출 일시가 유효하지 않을 경우 ApiException 던지도록 구현
- 1차 dto 검증에서 검출되지 않은 유효하지 않은 지출 일시 검증
- 단위 테스트코드로 테스트 완료

## 👨‍💻️ References

## 🙋‍ To reviewers